### PR TITLE
Enhanced exporter for stats,rate, api_name and default api_endpoints.

### DIFF
--- a/apis.txt
+++ b/apis.txt
@@ -1,6 +1,3 @@
-/axapi/v3/slb/sip/stats
-/axapi/v3/slb/mlb/stats
-/axapi/v3/slb/smtp/stats
-/axapi/v3/slb/fix/stats
-/axapi/v3/slb/service-group/http-sg/stats
-/axapi/v3/slb/server/demo_test/port/80+tcp/stats
+/system/control-cpu/stats
+/system/data-cpu/stats
+/system/memory/stats


### PR DESCRIPTION
1.) we Added backend handling for URL ending with "stats" and "rate" separately.
2.) Return default metrics if not api-endpoint is passed in prometheus.yml file, but Host IP is still mandatory.
3.) Removed "api_name" from prometheus.yml file and removed handling for the same in the exporter.